### PR TITLE
Add both the mustache path and mustache module suffix to the list of partials

### DIFF
--- a/lib/formats/esm.js
+++ b/lib/formats/esm.js
@@ -5,19 +5,23 @@
 module.exports = function (bundleName, templateName, moduleName, precompiled, partials, prefix) {
 
     // base dependency
-    var dependencies = ["template-base", "handlebars-base"];
+    var dependencies = ["template-base", "handlebars-base"],
+        // Used to store both the original file path and the dashed name
+        partialModuleToPathMap = {};
 
     // each partial should be provisioned thru another yui module
     // and the name of the partial should translate into a yui module
     // to become a dependency
     partials = partials || [];
-    // transform paths to custom naming convention
-    partials = partials.map(function (name) {
-        return name.replace(/\//g, '-');
-    });
-    partials.forEach(function (name) {
-        // adding prefix to each partial
-        dependencies.push((prefix || bundleName + '-tmpl-') + name);
+    partials.map(function (filePath) {
+        // transform paths to custom naming convention
+        var moduleSuffix = filePath.replace(/\//g, '-');
+        // map dashed module suffix to original file name
+        // Ex: { "path-to-mustache-file" : "path/to/mustache/file" }
+        partialModuleToPathMap[moduleSuffix] = filePath;
+        // add dependency
+        var dep = (prefix || bundleName + '-tmpl-') + moduleSuffix;
+        dependencies.push(dep);
     });
     var imports = dependencies.map(function (dep) {
         return "import '" + dep + "';";
@@ -29,10 +33,11 @@ module.exports = function (bundleName, templateName, moduleName, precompiled, pa
         'var fn = Y.Template.Handlebars.revive(' + precompiled + '),',
         '    partials = {};',
         '',
-        'Y.Array.each(' + JSON.stringify(partials) + ', function (name) {',
-        '    var fn = Y.Template.get("' + bundleName + '/" + name);',
+        'Y.Object.each(' + JSON.stringify(partialModuleToPathMap) + ', function (filePath, moduleSuffix) {',
+        '    var fn = Y.Template.get("' + bundleName + '/" + moduleSuffix);',
         '    if (fn) {',
-        '        partials[name] = fn;',
+        '        partials[filePath] = fn;',
+        '        partials[moduleSuffix] = fn;',
         '    }',
         '});',
         '',

--- a/lib/formats/esm.js
+++ b/lib/formats/esm.js
@@ -13,7 +13,7 @@ module.exports = function (bundleName, templateName, moduleName, precompiled, pa
     // and the name of the partial should translate into a yui module
     // to become a dependency
     partials = partials || [];
-    partials.map(function (filePath) {
+    partials.forEach(function (filePath) {
         // transform paths to custom naming convention
         var moduleSuffix = filePath.replace(/\//g, '-');
         // map dashed module suffix to original file name

--- a/lib/formats/yui.js
+++ b/lib/formats/yui.js
@@ -1,9 +1,3 @@
-/*
- * Copyright (c) 2013, Yahoo! Inc.  All rights reserved.
- * Copyrights licensed under the New BSD License.
- * See the accompanying LICENSE.txt file for terms.
- */
-
 /*jslint nomen:true, node:true */
 
 "use strict";
@@ -11,19 +5,22 @@
 module.exports = function (bundleName, templateName, moduleName, precompiled, partials, prefix) {
 
     // base dependency
-    var dependencies = ["template-base", "handlebars-base"];
+    var dependencies = ["template-base", "handlebars-base"],
+        // Used to store both the original file path and the dashed name
+        partialModuleToPathMap = {};
 
     // each partial should be provisioned thru another yui module
     // and the name of the partial should translate into a yui module
     // to become a dependency
     partials = partials || [];
-    // transform paths to custom naming convention
-    partials = partials.map(function (name) {
-        return name.replace(/\//g, '-');
-    });
-    partials.forEach(function (name) {
-        // adding prefix to each partial
-        dependencies.push((prefix || bundleName + '-tmpl-') + name);
+    partials.map(function (filePath) {
+        // transform paths to custom naming convention
+        var moduleSuffix = filePath.replace(/\//g, '-');
+        // map dashed module suffix to original file name
+        // Ex: { "path-to-mustache-file" : "path/to/mustache/file" }
+        partialModuleToPathMap[moduleSuffix] = filePath;
+        // add dependency
+        dependencies.push((prefix || bundleName + '-tmpl-') + moduleSuffix);
     });
 
     return [
@@ -31,10 +28,11 @@ module.exports = function (bundleName, templateName, moduleName, precompiled, pa
         '   var fn = Y.Template.Handlebars.revive(' + precompiled + '),',
         '       partials = {};',
         '',
-        '   Y.Array.each(' + JSON.stringify(partials) + ', function (name) {',
-        '       var fn = Y.Template.get("' + bundleName + '/" + name);',
+        '   Y.Object.each(' + JSON.stringify(partialModuleToPathMap) + ', function (filePath, moduleSuffix) {',
+        '       var fn = Y.Template.get("' + bundleName + '/" + moduleSuffix);',
         '       if (fn) {',
-        '           partials[name] = fn;',
+        '           partials[filePath] = fn;',
+        '           partials[moduleSuffix] = fn;',
         '       }',
         '   });',
         '',

--- a/lib/formats/yui.js
+++ b/lib/formats/yui.js
@@ -13,7 +13,7 @@ module.exports = function (bundleName, templateName, moduleName, precompiled, pa
     // and the name of the partial should translate into a yui module
     // to become a dependency
     partials = partials || [];
-    partials.map(function (filePath) {
+    partials.forEach(function (filePath) {
         // transform paths to custom naming convention
         var moduleSuffix = filePath.replace(/\//g, '-');
         // map dashed module suffix to original file name

--- a/tests/fixtures/testfile.handlebars
+++ b/tests/fixtures/testfile.handlebars
@@ -6,12 +6,12 @@
 <body>
     <h1>partial `baz` rendered at the client side: </h1>
 
-    <div id="barclient">{{>baz}}</div>
+    <div id="barclient">{{> dir/baz}}</div>
 
     {{#if people}}
-	    {{>abcd}}
+	    {{> dir/abcd}}
 	{{else}}
-	    {{>efgh}}
+	    {{> dir/efgh}}
 	{{/if}}
 </body>
 </html>

--- a/tests/lib/core.js
+++ b/tests/lib/core.js
@@ -23,9 +23,9 @@ describe('locator-handlebars', function () {
         it('partials', function () {
             var source = libfs.readFileSync(fixturesPath + '/testfile.handlebars', 'utf8'),
                 result = new Plugin().partialsParser(source);
-            expect(result[0]).to.equal('baz');
-            expect(result[1]).to.equal('abcd');
-            expect(result[2]).to.equal('efgh');
+            expect(result[0]).to.equal('dir/baz');
+            expect(result[1]).to.equal('dir/abcd');
+            expect(result[2]).to.equal('dir/efgh');
         });
 
         it('partialsdefault', function () {

--- a/tests/lib/plugin.js
+++ b/tests/lib/plugin.js
@@ -71,13 +71,13 @@ describe('locator-handlebars', function () {
                 filecall += 1;
                 expect(bundleName).to.equal("testing");
                 expect(relativePath).to.equal("testing-tmpl-testfile.js");
-                expect(contents.substring(0, 195)).to.equal([
+                expect(contents.substring(0, 207)).to.equal([
                     "// @module testing-tmpl-testfile",
                     "import 'template-base';",
                     "import 'handlebars-base';",
-                    "import 'testing-tmpl-baz';",
-                    "import 'testing-tmpl-abcd';",
-                    "import 'testing-tmpl-efgh';",
+                    "import 'testing-tmpl-dir-baz';",
+                    "import 'testing-tmpl-dir-abcd';",
+                    "import 'testing-tmpl-dir-efgh';",
                     "import Y from 'yui-instance';"
                 ].join('\n'));
                 return new libpromise.Promise(function (fulfill, reject) {


### PR DESCRIPTION
Filing PR for initial feedback. After this is done I will file a second PR with a more complete change.

 Now a module can reference a partial in 3 ways
- path-to-module
- path/to/module  (this is new)
- Custom partial mapping at registration

Things still TODO
- esm.js
- unit test

Things that we might TODO
- removing the "bundleName/"  from the so that we register templates as "static-profile-tmpl-dir-file" instead "profile/static-profile-tmpl-dir-file"
